### PR TITLE
Fix screen transitions.

### DIFF
--- a/app/src/main/java/com/example/pantryplan/ui/PantryPlanApp.kt
+++ b/app/src/main/java/com/example/pantryplan/ui/PantryPlanApp.kt
@@ -78,6 +78,7 @@ fun PantryPlanApp(appState: PantryPlanAppState) {
             AnimatedVisibility(
                 visible = destination != null,
                 enter = EnterTransition.None,
+                // Same as the default animation spec used by the NavHost.
                 exit = fadeOut(tween(700))
             ) {
                 NavigationBar {

--- a/core/design-system/src/main/res/values/dimens.xml
+++ b/core/design-system/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="horizontal_margin">16dp</dimen>
+    <dimen name="top_app_bar_height">64dp</dimen>
+    <dimen name="bottom_app_bar_height">80dp</dimen>
 </resources>

--- a/feature/meal-planner/src/main/java/com/example/pantryplan/feature/meals/MealPlannerScreen.kt
+++ b/feature/meal-planner/src/main/java/com/example/pantryplan/feature/meals/MealPlannerScreen.kt
@@ -1,21 +1,25 @@
 package com.example.pantryplan.feature.meals
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.dimensionResource
+import com.example.pantryplan.core.designsystem.R as designSystemR
 
 @Composable
 fun MealPlannerScreen() {
     Box (modifier = Modifier
         .navigationBarsPadding()
         .systemBarsPadding()
-        .padding(paddingValues = PaddingValues(top = 64.dp, bottom = 80.dp))) {
+        .padding(
+            top = dimensionResource(designSystemR.dimen.top_app_bar_height),
+            bottom = dimensionResource(designSystemR.dimen.bottom_app_bar_height)
+        )
+    ) {
         Text(
             text = "Hello Meal Planner!"
         )

--- a/feature/pantry/src/main/java/com/example/pantryplan/feature/pantry/PantryScreen.kt
+++ b/feature/pantry/src/main/java/com/example/pantryplan/feature/pantry/PantryScreen.kt
@@ -1,7 +1,6 @@
 package com.example.pantryplan.feature.pantry
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -16,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.pantryplan.core.designsystem.component.ContentUnavailable
@@ -31,11 +29,13 @@ fun PantryScreen(
     onCreatePantryItem: () -> Unit
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
-    Box(
-        modifier = Modifier
-            .navigationBarsPadding()
-            .systemBarsPadding()
-            .padding(paddingValues = PaddingValues(top = 64.dp, bottom = 80.dp))
+    Box(modifier = Modifier
+        .navigationBarsPadding()
+        .systemBarsPadding()
+        .padding(
+            top = dimensionResource(designSystemR.dimen.top_app_bar_height),
+            bottom = dimensionResource(designSystemR.dimen.bottom_app_bar_height)
+        )
     ) {
         if (uiState.value.pantryItems.isEmpty()) {
             PantryContentUnavailable()

--- a/feature/recipes/build.gradle.kts
+++ b/feature/recipes/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 
 dependencies {
     implementation(project(":core:models"))
+    implementation(project(":core:design-system"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/feature/recipes/src/main/java/com/example/pantryplan/feature/recipes/RecipesScreen.kt
+++ b/feature/recipes/src/main/java/com/example/pantryplan/feature/recipes/RecipesScreen.kt
@@ -1,21 +1,25 @@
 package com.example.pantryplan.feature.recipes
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.dimensionResource
+import com.example.pantryplan.core.designsystem.R as designSystemR
 
 @Composable
 fun RecipesScreen() {
     Box(modifier = Modifier
         .navigationBarsPadding()
         .systemBarsPadding()
-        .padding(paddingValues = PaddingValues(top = 64.dp, bottom = 80.dp))) {
+        .padding(
+            top = dimensionResource(designSystemR.dimen.top_app_bar_height),
+            bottom = dimensionResource(designSystemR.dimen.bottom_app_bar_height)
+        )
+    ) {
         Text(
             text = "Hello Recipes!"
         )


### PR DESCRIPTION
Fixes janky transitions between screens by ignoring the padding provided by the main Scaffold, leaving each screen within the NavHost to handle its own padding.

Sub-destinations like PantryItemDetailsScreen are unaffected by this lack of padding, because they contain Scaffolds which create their own padding.

Top-level destinations like the main pantry, recipes, and meal planner screens must pad themselves using the top_app_bar_height and bottom_app_bar_height dimensions provided in :core:designsystem's resources. 