### PR TITLE
Create InMemoryRecipeRepository

### DIFF
--- a/core/data-access/build.gradle.kts
+++ b/core/data-access/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     // Hilt plugins.
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+
+    id("kotlinx-serialization")
 }
 
 android {
@@ -39,6 +41,8 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+
+    implementation(libs.kotlinx.serialization.json)
 
     // Hilt dependencies.
     implementation(libs.hilt.android)

--- a/core/data-access/src/main/java/com/example/pantryplan/core/data/access/di/DataAccessModule.kt
+++ b/core/data-access/src/main/java/com/example/pantryplan/core/data/access/di/DataAccessModule.kt
@@ -1,7 +1,9 @@
 package com.example.pantryplan.core.data.access.di
 
+import com.example.pantryplan.core.data.access.repository.InMemoryRecipeRepository
 import com.example.pantryplan.core.data.access.repository.PantryItemRepository
 import com.example.pantryplan.core.data.access.repository.PantryItemRepositoryImpl
+import com.example.pantryplan.core.data.access.repository.RecipeRepository
 import com.example.pantryplan.core.data.access.repository.UserPreferencesRepository
 import com.example.pantryplan.core.data.access.repository.UserPreferencesRepositoryImpl
 import dagger.Binds
@@ -16,6 +18,11 @@ abstract class DataAccessModule {
     internal abstract fun bindPantryItemRepository(
         pantryItemRepository: PantryItemRepositoryImpl
     ): PantryItemRepository
+
+    @Binds
+    internal abstract fun bindRecipeRepository(
+        recipeRepository: InMemoryRecipeRepository
+    ): RecipeRepository
 
     @Binds
     internal abstract fun bindUserPreferencesRepository(

--- a/core/data-access/src/main/java/com/example/pantryplan/core/data/access/repository/InMemoryRecipeRepository.kt
+++ b/core/data-access/src/main/java/com/example/pantryplan/core/data/access/repository/InMemoryRecipeRepository.kt
@@ -1,0 +1,71 @@
+package com.example.pantryplan.core.data.access.repository
+
+import com.example.pantryplan.core.models.Recipe
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.util.UUID
+
+class InMemoryRecipeRepository : RecipeRepository {
+    private var recipes: MutableList<Recipe> = mutableListOf()
+    private val FLOW_REFRESH_DELAY: Long = 5000
+
+    override fun getAllRecipes(): Flow<List<Recipe>> = flow {
+        while (true) {
+            emit(recipes)
+            delay(FLOW_REFRESH_DELAY)
+        }
+    }
+
+    override fun getRecipeById(id: UUID): Flow<Recipe?> = flow {
+        while (true) {
+            try {
+                val existingRecipe = recipes.first { it.id == id }
+                emit(existingRecipe)
+            } catch (e: NoSuchElementException) {
+                emit(null)
+            }
+
+            delay(FLOW_REFRESH_DELAY)
+        }
+    }
+
+    override suspend fun addRecipe(recipe: Recipe) {
+        recipes.add(recipe)
+    }
+
+    override suspend fun addRecipeFromJson(json: String) {
+        try {
+            val recipe = Json.decodeFromString<Recipe>(json)
+            addRecipe(recipe)
+        } catch (_: SerializationException) {
+
+        } catch (_: IllegalArgumentException) {
+
+        }
+    }
+
+    override suspend fun removeItem(recipe: Recipe) {
+        recipes.remove(recipe)
+    }
+
+    override suspend fun updateRecipe(recipe: Recipe) {
+        try {
+            val existingRecipe = recipes.first { it.id == recipe.id }
+            val index = recipes.indexOf(existingRecipe)
+            recipes[index] = recipe
+        } catch (_: NoSuchElementException) {
+
+        }
+    }
+
+    override suspend fun getJsonForRecipe(recipe: Recipe): String? {
+        return try {
+            Json.encodeToString(recipe)
+        } catch (_: SerializationException) {
+            null
+        }
+    }
+}

--- a/core/data-access/src/main/java/com/example/pantryplan/core/data/access/repository/RecipeRepository.kt
+++ b/core/data-access/src/main/java/com/example/pantryplan/core/data/access/repository/RecipeRepository.kt
@@ -1,0 +1,18 @@
+package com.example.pantryplan.core.data.access.repository
+
+import com.example.pantryplan.core.models.Recipe
+import kotlinx.coroutines.flow.Flow
+import java.util.UUID
+
+interface RecipeRepository {
+    fun getAllRecipes(): Flow<List<Recipe>>
+    fun getRecipeById(id: UUID): Flow<Recipe?>
+
+    suspend fun addRecipe(recipe: Recipe)
+    suspend fun addRecipeFromJson(json: String)
+    suspend fun removeItem(recipe: Recipe)
+
+    suspend fun updateRecipe(recipe: Recipe)
+
+    suspend fun getJsonForRecipe(recipe: Recipe): String?
+}

--- a/core/models/build.gradle.kts
+++ b/core/models/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     id("java-library")
     alias(libs.plugins.jetbrains.kotlin.jvm)
+
+    id("kotlinx-serialization")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -13,4 +15,6 @@ kotlin {
 }
 dependencies {
     implementation(libs.kotlinx.datetime)
+
+    implementation(libs.kotlinx.serialization.json)
 }


### PR DESCRIPTION
Implements the RecipeRepository interface and provides an in-memory only implementation.
This should facilitate creating the rest of the recipe screens while we wait for the database to be completed.
Documentation will be added once the database version is done to use as reference.